### PR TITLE
Update compat for PlutoSliderServer to 1.0.0

### DIFF
--- a/.github/workflows/ExportPluto.yml
+++ b/.github/workflows/ExportPluto.yml
@@ -8,20 +8,19 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Install Julia
-              uses: julia-actions/setup-julia@v1
+              uses: julia-actions/setup-julia@v2
               with:
-                  version: 1.9
+                  version: "1"
 
             - name: Run & export Pluto notebooks
               run: |
                 julia -e 'using Pkg
                   Pkg.activate(mktempdir())
                   Pkg.add([
-                    Pkg.PackageSpec(name="PlutoSliderServer", version="0.3.2-0.3"),
-                    Pkg.PackageSpec(name="MsgPack"),
+                    Pkg.PackageSpec(name="PlutoSliderServer", version="1"),
                   ])
 
                   import PlutoSliderServer
@@ -34,8 +33,9 @@ jobs:
                   )'
 
             - name: Deploy to gh-pages
-              uses: JamesIves/github-pages-deploy-action@releases/v3
+              uses: JamesIves/github-pages-deploy-action@releases/v4
               with:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  BRANCH: gh-pages
-                  FOLDER: .
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: gh-pages
+                  folder: .
+                  single-commit: true


### PR DESCRIPTION
Hi! This is an automatic PR to update the PlutoSliderServer compat from 0.3 to 1.0.0! I did not test this PR, but PlutoSliderServer 1.0.0 had no breaking changes, except the new Julia 1.10 minimum ([release notes](https://github.com/JuliaPluto/PlutoSliderServer.jl/releases/tag/v1.0.0)).